### PR TITLE
Fix #24 Error When Disabling Schema Registry or Event Cache

### DIFF
--- a/src/EventDriven.EventBus.Dapr.EventCache.Mongo/EventDriven.EventBus.Dapr.EventCache.Mongo.csproj
+++ b/src/EventDriven.EventBus.Dapr.EventCache.Mongo/EventDriven.EventBus.Dapr.EventCache.Mongo.csproj
@@ -5,7 +5,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <Version>1.3.3</Version>
+        <Version>1.3.4</Version>
         <Authors>Tony Sneed</Authors>
         <Description>A MongoDB implementation of event caching with Dapr state store.</Description>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/EventDriven.EventBus.Dapr.EventCache.Mongo/ServiceCollectionExtensions.cs
+++ b/src/EventDriven.EventBus.Dapr.EventCache.Mongo/ServiceCollectionExtensions.cs
@@ -82,7 +82,9 @@ public static class ServiceCollectionExtensions
             options.EnableEventCacheCleanup = daprEventCacheOptions.EnableEventCacheCleanup;
             options.EventCacheCleanupInterval = daprEventCacheOptions.EventCacheCleanupInterval;
         });
+        services.AddSingleton<EventCacheOptions>(daprEventCacheOptions);
 
+        if (!daprEventCacheOptions.EnableEventCache) return services;
         services.AddSingleton<IEventCache, DaprEventCache>();
         services.AddSingleton<IEventHandlingRepository<DaprIntegrationEvent>,
             MongoEventHandlingRepository<DaprIntegrationEvent>>();

--- a/src/EventDriven.EventBus.Dapr/DaprEventBusEndpointRouteBuilderExtensions.cs
+++ b/src/EventDriven.EventBus.Dapr/DaprEventBusEndpointRouteBuilderExtensions.cs
@@ -38,7 +38,7 @@ namespace Microsoft.AspNetCore.Builder
             var daprClient = endpoints.ServiceProvider.GetService<DaprClient>();
             var daprEventCache = endpoints.ServiceProvider.GetService<IEventCache>();
             var daprEventBusOptions = endpoints.ServiceProvider.GetService<IOptions<DaprEventBusOptions>>();
-            var eventCacheOptions = endpoints.ServiceProvider.GetService<IOptions<EventCacheOptions>>();
+            var eventCacheOptions = endpoints.ServiceProvider.GetService<EventCacheOptions>();
 
             // Configure event bus
             logger?.LogInformation("Configuring event bus ...");
@@ -75,7 +75,7 @@ namespace Microsoft.AspNetCore.Builder
                         logger?.LogInformation("Handling event: {EventId}", @event?.Id);
                         try
                         {
-                            if (eventCacheOptions?.Value.EnableEventCache == false
+                            if (eventCacheOptions?.EnableEventCache == false
                                 || daprEventCache != null && await daprEventCache.TryAddAsync(@event!))
                                 await handler.HandleAsync(@event!);
                         }

--- a/src/EventDriven.EventBus.Dapr/EventDriven.EventBus.Dapr.csproj
+++ b/src/EventDriven.EventBus.Dapr/EventDriven.EventBus.Dapr.csproj
@@ -5,7 +5,7 @@
     <OutputType>Library</OutputType>
     <IsPackable>true</IsPackable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.3.3</Version>
+    <Version>1.3.4</Version>
     <Authors>Tony Sneed</Authors>
     <Description>An event bus abstraction layer over Dapr pub/sub.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/EventDriven.EventBus.EventCache.Mongo/EventDriven.EventBus.EventCache.Mongo.csproj
+++ b/src/EventDriven.EventBus.EventCache.Mongo/EventDriven.EventBus.EventCache.Mongo.csproj
@@ -5,7 +5,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <Version>1.3.3</Version>
+        <Version>1.3.4</Version>
         <Authors>Tony Sneed</Authors>
         <Description>A MongoDB implementation of event caching.</Description>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/EventDriven.EventBus.EventCache.Mongo/ServiceCollectionExtensions.cs
+++ b/src/EventDriven.EventBus.EventCache.Mongo/ServiceCollectionExtensions.cs
@@ -76,7 +76,9 @@ public static class ServiceCollectionExtensions
             options.EnableEventCacheCleanup = eventCacheOptions.EnableEventCacheCleanup;
             options.EventCacheCleanupInterval = eventCacheOptions.EventCacheCleanupInterval;
         });
+        services.AddSingleton<EventCacheOptions>(eventCacheOptions);
 
+        if (!eventCacheOptions.EnableEventCache) return services;
         services.AddSingleton<IEventCache, MongoEventCache>();
         services.AddSingleton<IEventHandlingRepository<DaprIntegrationEvent>,
             MongoEventHandlingRepository<DaprIntegrationEvent>>();


### PR DESCRIPTION
- Update AddMongoEventCache, AddDaprMongoEventCache to register EventCacheOptions and only add event cache if enabled
- Update AddDaprEventBus to check if schema registry is enabled
- Update MapDaprEventBus to get EventCacheOptions service instead of IOptions<EventCacheOptions>

Closes #24
