### PR TITLE
Fix #24 Error When Disabling Schema Registry or Event Cache (Configuration)

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -60,7 +60,7 @@ The purpose of the **Dapr Event Bus** project is to provide a thin abstraction l
     public void ConfigureServices(IServiceCollection services)
     {
         // Add Dapr Event Bus
-        services.AddDaprEventBus(Configuration, true);
+        services.AddDaprEventBus(Configuration);
 
         // Add Dapr Mongo event cache
         services.AddDaprMongoEventCache(Configuration);
@@ -156,6 +156,23 @@ The Schema Registry only validates messages when they are published to the Event
 > **Note**: **EventDriven.SchemaValidator.Json** uses `JSchemaGenerator` from [Newtonsoft.Json.Schema.Generation](https://www.newtonsoft.com/jsonschema/help/html/GeneratingSchemas.htm), which makes all fields *required* by default. To make fields optional, you need to use [EventDriven.SchemaRegistry.Api](https://github.com/event-driven-dotnet/EventDriven.SchemaRegistry.Api) to update the schema by removing required fields.
 
 To view all the registered schemas you can connect to the schema datastore directly, for example, using a MongoDB client such as [Robot 3T](https://robomongo.org/).
+
+## Disabling Schema Registry
+
+> It is recommended you **enable** schema registry to so that subscribers may be protected from breakage should a publisher change an event schema in a way that is not backwards compatible.
+>
+> However, if you wish to disable schema registry in a publisher, you may do so as follows.
+
+- Update the `DaprEventBusSchemaOptions` section in your appsettings.json file by setting `UseSchemaRegistry` to `false`.
+- Or simply remove the `DaprEventBusSchemaOptions` section altogether.
+
+## Disabling Event Cache
+
+> It is recommended you keep event cache **enabled** to make your subscriber idempotent and filter out duplicate events. This is the default behavior.
+>
+> However, if you wish to disable event cache in a subscriber, you may do so as follows.
+
+- Add a `MongoEventCacheOptions` section in your appsettings.json file and set `EnableEventCache` to `false`.
 
 ## Samples
 

--- a/samples/DuplexPubSub/Backend/Startup.cs
+++ b/samples/DuplexPubSub/Backend/Startup.cs
@@ -35,7 +35,7 @@ namespace Backend
             services.AddSingleton<WeatherForecastGeneratedEventHandler>();
 
             // Add Dapr service bus
-            services.AddDaprEventBus(Configuration, true);
+            services.AddDaprEventBus(Configuration);
             
             // Add Dapr Mongo event cache
             services.AddDaprMongoEventCache(Configuration);

--- a/samples/DuplexPubSub/ReadMe.md
+++ b/samples/DuplexPubSub/ReadMe.md
@@ -6,8 +6,7 @@ Demonstrates how to use Dapr Event Bus for duplex pub/sub.
 - Install [Docker Desktop](https://www.docker.com/products/docker-desktop) running Linux containers.
 - Install [Dapr CLI](https://docs.dapr.io/getting-started/install-dapr-cli/).
 - Run `dapr init`, `dapr --version`, `docker ps`
-- Run `dapr dashboard` from a terminal, then browse to http://localhost:8080.
-- [Dapr Visual Studio Extension](https://github.com/microsoft/vscode-dapr) (for debugging).
+- [Microsoft Tye](https://github.com/dotnet/tye/blob/main/docs/getting_started.md) (recommended)
 
 ## Introduction
 
@@ -45,48 +44,39 @@ The WeatherGenerator subscribes to the `WeatherForecastRequestedEvent`, creates 
 
 ## Running the Sample
 
-1. Open a terminal at the **Frontend** project root.
-   - Run the following Dapr command to start the frontend.
+1. Open a terminal at the **samples/DuplexPubSub** project root.
+   - Run the following command to start the frontend, weather-generator and backend projects using Tye.
 
     ```
-    dapr run --app-id frontend --app-port 5121 -- dotnet run
+    tye run
     ```
 
-2. Open a terminal at the **WeatherGenerator** project root.
-   - Run the following Dapr command to start the weather-generator.
-
-    ```
-    dapr run --app-id weather-generator --app-port 5321 --components-path ../dapr/components -- dotnet run
-    ```
-
-3. Open a terminal at the **Backend** project root.
-   - Run the following Dapr command to start the backend.
-
-    ```
-    dapr run --app-id backend --app-port 5221 --components-path ../dapr/components -- dotnet run
-    ```
-
-4. Open a terminal and run `dapr dashboard`.
-   - Browse to http://localhost:8080/
+2. Open the Tye dashboard.
+   - Browse to http://localhost:8000/
    - Verify that **frontend**, **backend** and **weather-generator** apps are running.
-5. Test with the Backend app.
+3. Test with the Backend app.
    - Browse to http://localhost:5221/weatherforecast
    - Refresh the browser to initiate requests.
    - There should be a 5 second latency before results are returned.
-6. Test with the Frontend app.
+4. Test with the Frontend app.
    - Browse to http://localhost:5121/
    - Click the "Get Weather Forecasts" button.
 
-## Debugging with Visual Studio Code
+## Debugging with Tye and the IDE of your choice
 
-1. Open the publisher and subscriber in separate VS Code instances.
+1. Open the weather-generator and backend projects in your IDE.
    - Set breakpoints where you want to pause code execution.
-2. Press Ctrl+P, enter `Dapr` and select `Scaffold Dapr Tasks`.
-   - Select .NET Core Attach
-   - Enter the app id (frontend, backend, weather-generator).
-   - Enter the port number.
-3. On the VS Code Debug tab select the `.NET Core Attach with Dapr` option.
-   - Start debugging the subscriber first by  clicking the Run button or pressing F5.
-   - Select the app process (Frontend.exe, Backend.exe, WeatherGenerator.exe).
-4. Browse to http://localhost:5200/
+2. Attach to the WeatherGenerator or Backend processes.
+3. Browse to http://localhost:5200/
    - Click the "Get Weather Forecasts" button.
+
+> If you need to debug startup code, start Tye with the `debug` flag.
+> Specify * for debugging all projects, or specify a project name.
+> Code execution will begin when you attach to the process.
+
+```
+tye run --debug *
+```
+```
+tye run --debug Backend
+```

--- a/samples/DuplexPubSub/WeatherGenerator/Startup.cs
+++ b/samples/DuplexPubSub/WeatherGenerator/Startup.cs
@@ -26,7 +26,7 @@ namespace WeatherGenerator
             services.AddSingleton<WeatherForecastRequestedEventHandler>();
 
             // Add Dapr service bus
-            services.AddDaprEventBus(Configuration, true);
+            services.AddDaprEventBus(Configuration);
             
             // Add Dapr Mongo event cache
             services.AddDaprMongoEventCache(Configuration);

--- a/samples/SimplePubSub/ReadMe.md
+++ b/samples/SimplePubSub/ReadMe.md
@@ -6,38 +6,37 @@ Demonstrates how to use Dapr Event Bus for simple pub/sub.
 - Install [Docker Desktop](https://www.docker.com/products/docker-desktop) running Linux containers.
 - Install [Dapr CLI](https://docs.dapr.io/getting-started/install-dapr-cli/).
 - Run `dapr init`, `dapr --version`, `docker ps`
-- Run `dapr dashboard` from a terminal, then browse to http://localhost:8080.
-- [Dapr Visual Studio Extension](https://github.com/microsoft/vscode-dapr) (for debugging).
+- [Microsoft Tye](https://github.com/dotnet/tye/blob/main/docs/getting_started.md) (recommended)
 
 ## Running the Sample
 
-1. Open a terminal at the **Subscriber** project root.
-   - Run the following Dapr command to start the subscriber.
+1. Open a terminal at the **samples/SimplePubSub** project root.
+   - Run the following command to start the publisher and subscriber projects using Tye.
 
     ```
-    dapr run --app-id subscriber --app-port 5252 --components-path ../dapr/components -- dotnet run
+    tye run
     ```
 
-2. Open a terminal at the **Publisher** project root.
-   - Run the following Dapr command to start the publisher.
-
-    ```
-    dapr run --app-id publisher --components-path ../dapr/components -- dotnet run
-    ```
+2. Open the Tye dashboard.
+   - Browse to http://localhost:8000/
+   - Verify that **publisher** and **subscriber** apps are running.
 
 3. Open a browser at http://localhost:5252/weatherforecast
    - Refresh the page every few seconds to see a new set of values.
-   - Note log output to each terminal.
 
-## Debugging with Visual Studio Code
+## Debugging with Tye and the IDE of your choice
 
-1. Open the publisher and subscriber in separate VS Code instances.
+1. Open the publisher and subscriber projects in your IDE.
    - Set breakpoints where you want to pause code execution.
-2. Press Ctrl+P, enter `Dapr` and select `Scaffold Dapr Tasks`.
-   - Select .NET Core Launch (web)
-   - Enter the app id (frontend, backend, weather-generator).
-   - Enter the port number.
-3. On the VS Code Debug tab select the `with Dapr` option.
-   - Start debugging the subscriber first by  clicking the Run button or pressing F5.
-4. Browse to http://localhost:5000/weatherforecast
-   - Refresh every few seconds to see a new set of values.
+2. Attach to the Publisher or Subscriber processes.
+
+> If you need to debug startup code, start Tye with the `debug` flag.
+> Specify * for debugging all projects, or specify a project name.
+> Code execution will begin when you attach to the process.
+
+```
+tye run --debug *
+```
+```
+tye run --debug Backend
+```

--- a/src/EventDriven.EventBus.Dapr.EventCache.Mongo/ServiceCollectionExtensions.cs
+++ b/src/EventDriven.EventBus.Dapr.EventCache.Mongo/ServiceCollectionExtensions.cs
@@ -43,7 +43,9 @@ public static class ServiceCollectionExtensions
             options.EnableEventCacheCleanup = daprEventCacheOptions.EnableEventCacheCleanup;
             options.EventCacheCleanupInterval = daprEventCacheOptions.EventCacheCleanupInterval;
         });
+        services.AddSingleton<EventCacheOptions>(daprEventCacheOptions);
 
+        if (!daprEventCacheOptions.EnableEventCache) return services;
         services.AddSingleton<IEventCache, DaprEventCache>();
         services.AddSingleton<IEventHandlingRepository<DaprIntegrationEvent>,
             MongoEventHandlingRepository<DaprIntegrationEvent>>();

--- a/src/EventDriven.EventBus.EventCache.Mongo/ServiceCollectionExtensions.cs
+++ b/src/EventDriven.EventBus.EventCache.Mongo/ServiceCollectionExtensions.cs
@@ -31,7 +31,7 @@ public static class ServiceCollectionExtensions
         mongoOptionsConfigSection.Bind(eventCacheOptions);
         if (!mongoOptionsConfigSection.Exists())
             throw new Exception($"Configuration section '{nameof(MongoEventCacheOptions)}' not present in app settings.");
-        if (string.IsNullOrWhiteSpace(eventCacheOptions.AppName))
+        if (eventCacheOptions.EnableEventCache && string.IsNullOrWhiteSpace(eventCacheOptions.AppName))
             throw new Exception($"Configuration section 'MongoEventCacheOptions:AppName' must be specified.");
 
         services.Configure<MongoEventCacheOptions>(options =>
@@ -42,7 +42,9 @@ public static class ServiceCollectionExtensions
             options.EnableEventCacheCleanup = eventCacheOptions.EnableEventCacheCleanup;
             options.EventCacheCleanupInterval = eventCacheOptions.EventCacheCleanupInterval;
         });
+        services.AddSingleton<EventCacheOptions>(eventCacheOptions);
 
+        if (!eventCacheOptions.EnableEventCache) return services;
         services.AddSingleton<IEventCache, MongoEventCache>();
         services.AddSingleton<IEventHandlingRepository<DaprIntegrationEvent>,
             MongoEventHandlingRepository<DaprIntegrationEvent>>();


### PR DESCRIPTION
- Update AddDaprMongoEventCache, AddMongoEventCache methods accepting IConfiguration to register EventCacheOptions and only add event cache if enabled
- Deprecate AddDaprEventBus method with useSchemaRegistry parameter, since this is already set via configuration.
- Update AddDaprEventBus method accepting IConfiguration to pass configuration values to AddDaprEventBus method accepting pubsub name and configureSchemaOptions
- Update ReadMe file with info on disabling schema registry and event cache
- Update debugging sections of sample ReadMe files to use Tye instead of VS Code

Closes #24