### PR TITLE
Update Schema Validator to Replace Newtonsoft.Json.Schema with NJsonSchema

### DIFF
--- a/samples/DuplexPubSub/Common/Common.csproj
+++ b/samples/DuplexPubSub/Common/Common.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="EventDriven.EventBus.Abstractions" Version="1.3.1" />
+    <PackageReference Include="EventDriven.EventBus.Abstractions" Version="1.3.2" />
   </ItemGroup>
 
 </Project>

--- a/samples/DuplexPubSub/Frontend/Frontend.csproj
+++ b/samples/DuplexPubSub/Frontend/Frontend.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapr.AspNetCore" Version="1.10.0" />
+    <PackageReference Include="Dapr.AspNetCore" Version="1.11.0" />
   </ItemGroup>
 
 </Project>

--- a/src/EventDriven.EventBus.Dapr.EventCache.Mongo/EventDriven.EventBus.Dapr.EventCache.Mongo.csproj
+++ b/src/EventDriven.EventBus.Dapr.EventCache.Mongo/EventDriven.EventBus.Dapr.EventCache.Mongo.csproj
@@ -5,7 +5,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <Version>1.3.6</Version>
+        <Version>1.3.8</Version>
         <Authors>Tony Sneed</Authors>
         <Description>A MongoDB implementation of event caching with Dapr state store.</Description>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -14,16 +14,16 @@
         <RepositoryUrl>https://github.com/event-driven-dotnet/EventDriven.EventBus.Dapr.git</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageTags>event-bus event-cache event-driven event-driven-architecture dapr</PackageTags>
-        <PackageReleaseNotes>https://github.com/event-driven-dotnet/EventDriven.EventBus.Dapr/releases/tag/v1.3.6</PackageReleaseNotes>
+        <PackageReleaseNotes>https://github.com/event-driven-dotnet/EventDriven.EventBus.Dapr/releases/tag/v1.3.8</PackageReleaseNotes>
         <PackageId>EventDriven.EventBus.Dapr.EventCache.Mongo</PackageId>
         <GenerateDocumentationFile>True</GenerateDocumentationFile>
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Dapr.AspNetCore" Version="1.10.0" />
-      <PackageReference Include="EventDriven.DependencyInjection.URF.Mongo" Version="1.2.1" />
-      <PackageReference Include="EventDriven.EventBus.Abstractions" Version="1.3.1" />
-      <PackageReference Include="MongoDB.Driver" Version="2.19.1" />
+      <PackageReference Include="Dapr.AspNetCore" Version="1.11.0" />
+      <PackageReference Include="EventDriven.DependencyInjection.URF.Mongo" Version="1.2.2" />
+      <PackageReference Include="EventDriven.EventBus.Abstractions" Version="1.3.2" />
+      <PackageReference Include="MongoDB.Driver" Version="2.21.0" />
       <PackageReference Include="URF.Core.Mongo" Version="7.0.0" />
     </ItemGroup>
 

--- a/src/EventDriven.EventBus.Dapr/EventDriven.EventBus.Dapr.csproj
+++ b/src/EventDriven.EventBus.Dapr/EventDriven.EventBus.Dapr.csproj
@@ -5,7 +5,7 @@
     <OutputType>Library</OutputType>
     <IsPackable>true</IsPackable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.3.7</Version>
+    <Version>1.3.8</Version>
     <Authors>Tony Sneed</Authors>
     <Description>An event bus abstraction layer over Dapr pub/sub.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -14,17 +14,17 @@
     <RepositoryUrl>https://github.com/event-driven-dotnet/EventDriven.EventBus.Dapr.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>event-bus event-driven event-driven-architecture dapr</PackageTags>
-    <PackageReleaseNotes>https://github.com/event-driven-dotnet/EventDriven.EventBus.Dapr/releases/tag/v1.3.7</PackageReleaseNotes>
+    <PackageReleaseNotes>https://github.com/event-driven-dotnet/EventDriven.EventBus.Dapr/releases/tag/v1.3.8</PackageReleaseNotes>
     <PackageId>EventDriven.EventBus.Dapr</PackageId>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapr.AspNetCore" Version="1.10.0" />
-    <PackageReference Include="EventDriven.EventBus.Abstractions" Version="1.3.1" />
-    <PackageReference Include="EventDriven.SchemaRegistry.Mongo" Version="1.2.2" />
-    <PackageReference Include="EventDriven.SchemaValidator.Json" Version="1.1.1" />
+    <PackageReference Include="Dapr.AspNetCore" Version="1.11.0" />
+    <PackageReference Include="EventDriven.EventBus.Abstractions" Version="1.3.2" />
+    <PackageReference Include="EventDriven.SchemaRegistry.Mongo" Version="1.2.3" />
+    <PackageReference Include="EventDriven.SchemaValidator.Json" Version="2.0.0" />
     <PackageReference Include="NeoSmart.AsyncLock" Version="3.2.1" />
   </ItemGroup>
 

--- a/src/EventDriven.EventBus.EventCache.Mongo/EventDriven.EventBus.EventCache.Mongo.csproj
+++ b/src/EventDriven.EventBus.EventCache.Mongo/EventDriven.EventBus.EventCache.Mongo.csproj
@@ -5,7 +5,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <Version>1.3.6</Version>
+        <Version>1.3.8</Version>
         <Authors>Tony Sneed</Authors>
         <Description>A MongoDB implementation of event caching.</Description>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -14,15 +14,15 @@
         <RepositoryUrl>https://github.com/event-driven-dotnet/EventDriven.EventBus.Dapr.git</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageTags>event-bus event-cache event-driven event-driven-architecture</PackageTags>
-        <PackageReleaseNotes>https://github.com/event-driven-dotnet/EventDriven.EventBus.Dapr/releases/tag/v1.3.6</PackageReleaseNotes>
+        <PackageReleaseNotes>https://github.com/event-driven-dotnet/EventDriven.EventBus.Dapr/releases/tag/v1.3.8</PackageReleaseNotes>
         <PackageId>EventDriven.EventBus.EventCache.Mongo</PackageId>
         <GenerateDocumentationFile>True</GenerateDocumentationFile>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="EventDriven.DependencyInjection.URF.Mongo" Version="1.2.1" />
-        <PackageReference Include="EventDriven.EventBus.Abstractions" Version="1.3.1" />
-        <PackageReference Include="MongoDB.Driver" Version="2.19.1" />
+        <PackageReference Include="EventDriven.DependencyInjection.URF.Mongo" Version="1.2.2" />
+        <PackageReference Include="EventDriven.EventBus.Abstractions" Version="1.3.2" />
+        <PackageReference Include="MongoDB.Driver" Version="2.21.0" />
         <PackageReference Include="URF.Core.Mongo" Version="7.0.0" />
     </ItemGroup>
 


### PR DESCRIPTION
- Update EventDriven.SchemaValidatgor.Json to 2.0.0
   - Uses NJsonSchema instead of Newtonsoft.Json.Schema
- Update other NuGet packages
