### PR TITLE
Add Retry Support

### DIFF
--- a/samples/DuplexPubSub/Backend/Backend.csproj
+++ b/samples/DuplexPubSub/Backend/Backend.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\src\EventDriven.EventBus.Dapr.EventCache.Mongo\EventDriven.EventBus.Dapr.EventCache.Mongo.csproj" />
+    <ProjectReference Include="..\..\..\src\EventDriven.EventBus.EventCache.Mongo\EventDriven.EventBus.EventCache.Mongo.csproj" />
     <ProjectReference Include="..\..\..\src\EventDriven.EventBus.Dapr\EventDriven.EventBus.Dapr.csproj" />
     <ProjectReference Include="..\Common\Common.csproj" />
   </ItemGroup>

--- a/samples/DuplexPubSub/Backend/Handlers/WeatherForecastGeneratedEventHandler.cs
+++ b/samples/DuplexPubSub/Backend/Handlers/WeatherForecastGeneratedEventHandler.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.Extensions.Logging;
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
 using System.Threading.Tasks;
 using Backend.Repositories;
 using Common.Events;
@@ -8,8 +10,12 @@ namespace Backend.Handlers
 {
     public class WeatherForecastGeneratedEventHandler : IntegrationEventHandler<WeatherForecastGeneratedEvent>
     {
+        // Set true to generate errors for retries
+        private const bool GenerateErrorsForRetries = false;
+
         private readonly WeatherForecastRepository _weatherRepo;
         private readonly ILogger<WeatherForecastGeneratedEventHandler> _logger;
+        private readonly List<string> _eventIds = new();
 
         public WeatherForecastGeneratedEventHandler(WeatherForecastRepository weatherRepo, ILogger<WeatherForecastGeneratedEventHandler> logger)
         {
@@ -20,6 +26,14 @@ namespace Backend.Handlers
         public override Task HandleAsync(WeatherForecastGeneratedEvent @event)
         {
             _logger.LogInformation("Weather posted");
+
+            // Throw exception the first time we process this event
+            if (GenerateErrorsForRetries && !_eventIds.Contains(@event.Id))
+            {
+                _eventIds.Add(@event.Id);
+                throw new Exception("Weather processing exception. Retry pending.");
+            }
+
             _weatherRepo.WeatherForecasts = @event.WeatherForecasts;
             return Task.CompletedTask;
         }

--- a/samples/DuplexPubSub/Backend/Startup.cs
+++ b/samples/DuplexPubSub/Backend/Startup.cs
@@ -37,8 +37,8 @@ namespace Backend
             // Add Dapr service bus
             services.AddDaprEventBus(Configuration);
             
-            // Add Dapr Mongo event cache
-            services.AddDaprMongoEventCache(Configuration);
+            // Add Mongo event cache
+            services.AddMongoEventCache(Configuration);
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/samples/DuplexPubSub/Backend/appsettings.json
+++ b/samples/DuplexPubSub/Backend/appsettings.json
@@ -10,10 +10,10 @@
   "DaprEventBusOptions": {
     "PubSubName": "pubsub"
   },
-  "DaprEventCacheOptions": {
-    "EnableEventCache" : false
+  "MongoEventCacheOptions": {
+    "AppName": "backend"
   },
-  "DaprStoreDatabaseSettings": {
+  "MongoStoreDatabaseSettings": {
     "ConnectionString": "mongodb://localhost:27017",
     "DatabaseName": "daprStore",
     "CollectionName": "daprCollection"

--- a/samples/DuplexPubSub/Common/Common.csproj
+++ b/samples/DuplexPubSub/Common/Common.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="EventDriven.EventBus.Abstractions" Version="1.3.2" />
+    <PackageReference Include="EventDriven.EventBus.Abstractions" Version="1.4.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/DuplexPubSub/Frontend/Frontend.csproj
+++ b/samples/DuplexPubSub/Frontend/Frontend.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapr.AspNetCore" Version="1.11.0" />
+    <PackageReference Include="Dapr.AspNetCore" Version="1.12.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/DuplexPubSub/WeatherGenerator/Startup.cs
+++ b/samples/DuplexPubSub/WeatherGenerator/Startup.cs
@@ -28,8 +28,8 @@ namespace WeatherGenerator
             // Add Dapr service bus
             services.AddDaprEventBus(Configuration);
             
-            // Add Dapr Mongo event cache
-            services.AddDaprMongoEventCache(Configuration);
+            // Add Mongo event cache
+            services.AddMongoEventCache(Configuration);
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/samples/DuplexPubSub/WeatherGenerator/WeatherGenerator.csproj
+++ b/samples/DuplexPubSub/WeatherGenerator/WeatherGenerator.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\src\EventDriven.EventBus.Dapr.EventCache.Mongo\EventDriven.EventBus.Dapr.EventCache.Mongo.csproj" />
+    <ProjectReference Include="..\..\..\src\EventDriven.EventBus.EventCache.Mongo\EventDriven.EventBus.EventCache.Mongo.csproj" />
     <ProjectReference Include="..\..\..\src\EventDriven.EventBus.Dapr\EventDriven.EventBus.Dapr.csproj" />
     <ProjectReference Include="..\Common\Common.csproj" />
   </ItemGroup>

--- a/samples/DuplexPubSub/WeatherGenerator/appsettings.json
+++ b/samples/DuplexPubSub/WeatherGenerator/appsettings.json
@@ -10,12 +10,10 @@
   "DaprEventBusOptions": {
     "PubSubName": "pubsub"
   },
-  "DaprEventCacheOptions": {
-    "DaprStateStoreOptions": {
-      "StateStoreName": "statestore-mongodb"
-    }
+  "MongoEventCacheOptions": {
+    "AppName": "weather-generator"
   },
-  "DaprStoreDatabaseSettings": {
+  "MongoStoreDatabaseSettings": {
     "ConnectionString": "mongodb://localhost:27017",
     "DatabaseName": "daprStore",
     "CollectionName": "daprCollection"

--- a/src/EventDriven.EventBus.Dapr.EventCache.Mongo/DaprEventCache.cs
+++ b/src/EventDriven.EventBus.Dapr.EventCache.Mongo/DaprEventCache.cs
@@ -20,6 +20,11 @@ public class DaprEventCache : IEventCache
     protected Timer? CleanupTimer { get; }
 
     /// <summary>
+    /// Errors cleanup timer.
+    /// </summary>
+    protected Timer? ErrorsCleanupTimer { get; }
+
+    /// <summary>
     /// Cancellation token.
     /// </summary>
     public CancellationToken CancellationToken { get; }
@@ -41,15 +46,21 @@ public class DaprEventCache : IEventCache
         _eventHandlingRepository = eventHandlingRepository;
         _eventCacheOptions = eventCacheOptions.Value;
         CancellationToken = cancellationToken;
-        async void TimerCallback(object state) => await CleanupEventCacheAsync();
         if (_eventCacheOptions.DaprEventCacheType == DaprEventCacheType.Queryable &&
             _eventCacheOptions.EnableEventCacheCleanup)
+        {
             CleanupTimer = new Timer(TimerCallback!, null, TimeSpan.Zero, 
                 _eventCacheOptions.EventCacheCleanupInterval);
+            ErrorsCleanupTimer = new Timer(ErrorsTimerCallback, null, TimeSpan.Zero, 
+                _eventCacheOptions.EventErrorsCacheCleanupInterval);
+        }
+        return;
+        async void TimerCallback(object state) => await CleanupEventCacheAsync();
+        async void ErrorsTimerCallback(object? state) => await CleanupEventCacheErrorsAsync();
     }
 
     /// <summary>
-    /// Cleans up event cache.
+    /// Clean up event cache.
     /// </summary>
     /// <returns>Task that will complete when the operation has completed.</returns>
     protected virtual async Task CleanupEventCacheAsync()
@@ -65,8 +76,38 @@ public class DaprEventCache : IEventCache
                 return;
             }
             
-            // Remove expired events
-            var events = await _eventHandlingRepository.GetExpiredEventsAsync(null, CancellationToken);
+            // Remove expired events without errors
+            var events = 
+                await _eventHandlingRepository.GetExpiredEventsAsync(null, true, CancellationToken);
+            foreach (var @event in events)
+            {
+                if (@event.Value != null)
+                    await _dapr.DeleteStateAsync(_eventCacheOptions.DaprStateStoreOptions.StateStoreName,
+                        @event.Value.EventId, null, null, CancellationToken);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Clean up event cache errors.
+    /// </summary>
+    /// <returns>Task that will complete when the operation has completed.</returns>
+    protected virtual async Task CleanupEventCacheErrorsAsync()
+    {
+        using (await _syncRoot.LockAsync())
+        {
+            // End timer and exit if cache cleanup disabled or cancellation pending
+            if (!(_eventCacheOptions.DaprEventCacheType == DaprEventCacheType.Queryable &&
+                  _eventCacheOptions.EnableEventCacheCleanup)
+                || CancellationToken.IsCancellationRequested)
+            {
+                if (ErrorsCleanupTimer != null) await ErrorsCleanupTimer.DisposeAsync();
+                return;
+            }
+            
+            // Remove expired events with errors
+            var events = 
+                await _eventHandlingRepository.GetExpiredEventsAsync(null, false, CancellationToken);
             foreach (var @event in events)
             {
                 if (@event.Value != null)
@@ -77,29 +118,40 @@ public class DaprEventCache : IEventCache
     }
 
     /// <inheritdoc />
-    public bool TryAdd(IntegrationEvent @event) =>
-        TryAddAsync(@event).Result;
+    public async Task<bool> HasBeenHandledAsync(IntegrationEvent @event, string handlerTypeName)
+    {
+        // Return false if not enabled
+        if (!_eventCacheOptions.EnableEventCache) return false;
+        
+        // Return true if event exists, is not expired, and handler has no error
+        var wrapper = await _dapr.GetStateAsync<EventHandling>(_eventCacheOptions
+            .DaprStateStoreOptions.StateStoreName, @event.Id, null, null, CancellationToken);
+        var exists = wrapper != null;
+        var expired =
+            wrapper != null &&
+            DateTime.UtcNow > wrapper.EventHandledTime + wrapper.EventHandledTimeout;
+        var hasError =
+            wrapper != null &&
+            wrapper.Handlers.ContainsKey(handlerTypeName) &&
+            wrapper.Handlers[handlerTypeName].HasError;
+        var hasBeenHandled = exists && !(expired || hasError);
+        return hasBeenHandled;
+    }
 
     /// <inheritdoc />
-    public virtual async Task<bool> TryAddAsync(IntegrationEvent @event)
+    public virtual async Task AddEventAsync(IntegrationEvent @event,
+        string? handlerTypeName = null, string? errorMessage = null)
     {
         using (await _syncRoot.LockAsync())
         {
-            // Return true if not enabled
-            if (!_eventCacheOptions.EnableEventCache) return true;
+            // Return if cache not enabled
+            if (!_eventCacheOptions.EnableEventCache) return;
         
-            // Return false if event exists and is not expired
-            var existing = await _dapr.GetStateAsync<EventHandling>(_eventCacheOptions
+            // Remove existing event
+            await _dapr.DeleteStateAsync(_eventCacheOptions
                 .DaprStateStoreOptions.StateStoreName, @event.Id, null, null, CancellationToken);
-            if (existing != null && existing.EventHandledTimeout < DateTime.UtcNow - existing.EventHandledTime)
-                return false;
-        
-            // Remove existing if event is expired
-            if (existing != null)
-                await _dapr.DeleteStateAsync(_eventCacheOptions
-                    .DaprStateStoreOptions.StateStoreName, @event.Id, null, null, CancellationToken);
             
-            // Add event handling
+            // Add new event
             var handling = new EventHandling
             {
                 EventId = @event.Id,
@@ -107,9 +159,18 @@ public class DaprEventCache : IEventCache
                 EventHandledTime = DateTime.UtcNow,
                 EventHandledTimeout = _eventCacheOptions.EventCacheTimeout
             };
+            if (!string.IsNullOrWhiteSpace(handlerTypeName))
+            {
+                handling.Handlers.Add(handlerTypeName, new HandlerInfo
+                {
+                    HasError = !string.IsNullOrWhiteSpace(errorMessage),
+                    ErrorMessage = !string.IsNullOrWhiteSpace(errorMessage)
+                        ? errorMessage : null
+                });
+            }
+
             await _dapr.SaveStateAsync(_eventCacheOptions.DaprStateStoreOptions.StateStoreName,
                 @event.Id, handling, null, null, CancellationToken);
-            return true;
         }
     }
 }

--- a/src/EventDriven.EventBus.Dapr.EventCache.Mongo/EventDriven.EventBus.Dapr.EventCache.Mongo.csproj
+++ b/src/EventDriven.EventBus.Dapr.EventCache.Mongo/EventDriven.EventBus.Dapr.EventCache.Mongo.csproj
@@ -20,10 +20,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Dapr.AspNetCore" Version="1.11.0" />
+      <PackageReference Include="Dapr.AspNetCore" Version="1.12.0" />
       <PackageReference Include="EventDriven.DependencyInjection.URF.Mongo" Version="1.2.2" />
-      <PackageReference Include="EventDriven.EventBus.Abstractions" Version="1.3.2" />
-      <PackageReference Include="MongoDB.Driver" Version="2.21.0" />
+      <PackageReference Include="EventDriven.EventBus.Abstractions" Version="1.4.0" />
+      <PackageReference Include="MongoDB.Driver" Version="2.22.0" />
       <PackageReference Include="URF.Core.Mongo" Version="7.0.0" />
     </ItemGroup>
 

--- a/src/EventDriven.EventBus.Dapr/DaprEventBusOptions.cs
+++ b/src/EventDriven.EventBus.Dapr/DaprEventBusOptions.cs
@@ -9,5 +9,10 @@
         /// Dapr PubSub component name.
         /// </summary>
         public string PubSubName { get; set; } = "pubsub";
+        
+        /// <summary>
+        /// Disable retries.
+        /// </summary>
+        public bool DisableRetries { get; set; }
     }
 }

--- a/src/EventDriven.EventBus.Dapr/EventDriven.EventBus.Dapr.csproj
+++ b/src/EventDriven.EventBus.Dapr/EventDriven.EventBus.Dapr.csproj
@@ -5,7 +5,7 @@
     <OutputType>Library</OutputType>
     <IsPackable>true</IsPackable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.3.8</Version>
+    <Version>1.4.0</Version>
     <Authors>Tony Sneed</Authors>
     <Description>An event bus abstraction layer over Dapr pub/sub.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -14,15 +14,15 @@
     <RepositoryUrl>https://github.com/event-driven-dotnet/EventDriven.EventBus.Dapr.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>event-bus event-driven event-driven-architecture dapr</PackageTags>
-    <PackageReleaseNotes>https://github.com/event-driven-dotnet/EventDriven.EventBus.Dapr/releases/tag/v1.3.8</PackageReleaseNotes>
+    <PackageReleaseNotes>https://github.com/event-driven-dotnet/EventDriven.EventBus.Dapr/releases/tag/v1.4.0</PackageReleaseNotes>
     <PackageId>EventDriven.EventBus.Dapr</PackageId>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapr.AspNetCore" Version="1.11.0" />
-    <PackageReference Include="EventDriven.EventBus.Abstractions" Version="1.3.2" />
+    <PackageReference Include="Dapr.AspNetCore" Version="1.12.0" />
+    <PackageReference Include="EventDriven.EventBus.Abstractions" Version="1.4.0" />
     <PackageReference Include="EventDriven.SchemaRegistry.Mongo" Version="1.2.3" />
     <PackageReference Include="EventDriven.SchemaValidator.Json" Version="2.0.0" />
     <PackageReference Include="NeoSmart.AsyncLock" Version="3.2.1" />

--- a/src/EventDriven.EventBus.EventCache.Mongo/EventDriven.EventBus.EventCache.Mongo.csproj
+++ b/src/EventDriven.EventBus.EventCache.Mongo/EventDriven.EventBus.EventCache.Mongo.csproj
@@ -21,8 +21,8 @@
 
     <ItemGroup>
         <PackageReference Include="EventDriven.DependencyInjection.URF.Mongo" Version="1.2.2" />
-        <PackageReference Include="EventDriven.EventBus.Abstractions" Version="1.3.2" />
-        <PackageReference Include="MongoDB.Driver" Version="2.21.0" />
+        <PackageReference Include="EventDriven.EventBus.Abstractions" Version="1.4.0" />
+        <PackageReference Include="MongoDB.Driver" Version="2.22.0" />
         <PackageReference Include="URF.Core.Mongo" Version="7.0.0" />
     </ItemGroup>
 

--- a/src/EventDriven.EventBus.EventCache.Mongo/EventWrapperDto.cs
+++ b/src/EventDriven.EventBus.EventCache.Mongo/EventWrapperDto.cs
@@ -24,4 +24,10 @@ public class EventWrapperDto
     /// </summary>
     [BsonElement("value")]
     public string Value { get; set; } = null!;
+    
+    /// <summary>
+    /// Event wrapper ttl.
+    /// </summary>
+    [BsonElement("_ttl")]
+    public string Ttl { get; set; } = null!;
 }

--- a/src/EventDriven.EventBus.EventCache.Mongo/MongoEventCache.cs
+++ b/src/EventDriven.EventBus.EventCache.Mongo/MongoEventCache.cs
@@ -17,6 +17,11 @@ public class MongoEventCache : IEventCache
     protected Timer? CleanupTimer { get; }
 
     /// <summary>
+    /// Errors cleanup timer.
+    /// </summary>
+    protected Timer? ErrorsCleanupTimer { get; }
+
+    /// <summary>
     /// Cancellation token.
     /// </summary>
     public CancellationToken CancellationToken { get; }
@@ -35,14 +40,20 @@ public class MongoEventCache : IEventCache
         _eventCacheOptions = eventCacheOptions.Value;
         _eventHandlingRepository = eventHandlingRepository;
         CancellationToken = cancellationToken;
-        async void TimerCallback(object state) => await CleanupEventCacheAsync();
         if (_eventCacheOptions.EnableEventCacheCleanup)
+        {
             CleanupTimer = new Timer(TimerCallback!, null, TimeSpan.Zero, 
                 _eventCacheOptions.EventCacheCleanupInterval);
+            ErrorsCleanupTimer = new Timer(ErrorsTimerCallback, null, TimeSpan.Zero, 
+                _eventCacheOptions.EventErrorsCacheCleanupInterval);
+        }
+        return;
+        async void TimerCallback(object state) => await CleanupEventCacheAsync();
+        async void ErrorsTimerCallback(object? state) => await CleanupEventCacheErrorsAsync();
     }
 
     /// <summary>
-    /// Cleans up event cache.
+    /// Clean up event cache.
     /// </summary>
     /// <returns>Task that will complete when the operation has completed.</returns>
     protected virtual async Task CleanupEventCacheAsync()
@@ -57,9 +68,37 @@ public class MongoEventCache : IEventCache
                 return;
             }
             
-            // Remove expired events
+            // Remove expired events without errors
             var events = await _eventHandlingRepository.GetExpiredEventsAsync(
-                _eventCacheOptions.AppName, CancellationToken);
+                _eventCacheOptions.AppName, true, CancellationToken);
+            foreach (var @event in events)
+            {
+                if (@event.Value != null)
+                    await _eventHandlingRepository.DeleteEventAsync(_eventCacheOptions.AppName,
+                        @event.Value.EventId, CancellationToken);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Clean up event cache errors.
+    /// </summary>
+    /// <returns>Task that will complete when the operation has completed.</returns>
+    protected virtual async Task CleanupEventCacheErrorsAsync()
+    {
+        using (await _syncRoot.LockAsync())
+        {
+            // End timer and exit if cache cleanup disabled or cancellation pending
+            if (!_eventCacheOptions.EnableEventCacheCleanup
+                || CancellationToken.IsCancellationRequested)
+            {
+                if (ErrorsCleanupTimer != null) await ErrorsCleanupTimer.DisposeAsync();
+                return;
+            }
+            
+            // Remove expired events with errors
+            var events = await _eventHandlingRepository.GetExpiredEventsAsync(
+                _eventCacheOptions.AppName, false, CancellationToken);
             foreach (var @event in events)
             {
                 if (@event.Value != null)
@@ -70,27 +109,42 @@ public class MongoEventCache : IEventCache
     }
 
     /// <inheritdoc />
-    public bool TryAdd(IntegrationEvent @event) =>
-        TryAddAsync(@event).Result;
-
-    /// <inheritdoc />
-    public async Task<bool> TryAddAsync(IntegrationEvent @event)
+    public async Task<bool> HasBeenHandledAsync(IntegrationEvent @event, string handlerTypeName)
     {
         using (await _syncRoot.LockAsync())
         {
-            // Return true if not enabled
-            if (!_eventCacheOptions.EnableEventCache) return true;
-        
-            // Return false if event exists and is not expired
-            var existing = await _eventHandlingRepository.GetEventAsync(
+            // Return false if cache not enabled
+            if (!_eventCacheOptions.EnableEventCache) return false;
+
+            // Return true if event exists, is not expired, and handler has no error
+            var wrapper = await _eventHandlingRepository.GetEventAsync(
                 _eventCacheOptions.AppName, @event.Id, CancellationToken);
-            if (existing?.Value != null && existing.Value.EventHandledTimeout < DateTime.UtcNow - existing.Value.EventHandledTime)
-                return false;
+            var exists = wrapper?.Value != null;
+            var expired =
+                wrapper?.Value != null &&
+                DateTime.UtcNow > wrapper.Value.EventHandledTime + wrapper.Value.EventHandledTimeout;
+            var hasError =
+                wrapper?.Value != null &&
+                wrapper.Value.Handlers.ContainsKey(handlerTypeName) &&
+                wrapper.Value.Handlers[handlerTypeName].HasError;
+            var hasBeenHandled = exists && !(expired || hasError);
+            return hasBeenHandled;
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task AddEventAsync(IntegrationEvent @event,
+        string? handlerTypeName = null, string? errorMessage = null)
+    {
+        using (await _syncRoot.LockAsync())
+        {
+            // Return if cache not enabled
+            if (!_eventCacheOptions.EnableEventCache) return;
         
-            // Remove existing if event is expired
+            // Remove existing event
             await _eventHandlingRepository.DeleteEventAsync(_eventCacheOptions.AppName, @event.Id, CancellationToken);
             
-            // Add event handling
+            // Add new event
             var handling = new EventHandling
             {
                 EventId = @event.Id,
@@ -98,9 +152,18 @@ public class MongoEventCache : IEventCache
                 EventHandledTime = DateTime.UtcNow,
                 EventHandledTimeout = _eventCacheOptions.EventCacheTimeout
             };
+            if (!string.IsNullOrWhiteSpace(handlerTypeName))
+            {
+                handling.Handlers.Add(handlerTypeName, new HandlerInfo
+                {
+                    HasError = !string.IsNullOrWhiteSpace(errorMessage),
+                    ErrorMessage = !string.IsNullOrWhiteSpace(errorMessage)
+                        ? errorMessage : null
+                });
+            }
+
             await _eventHandlingRepository.AddEventAsync(_eventCacheOptions.AppName, @event.Id,
                 handling, CancellationToken);
-            return true;
         }
     }
 }


### PR DESCRIPTION
- Refactor MongoEventCache, DaprEventCache and MapDaprEventBus endpoint route builder to support retries when errors occur
- Add _ttl property to EventWrapperDto to fix serialization error
- Update EventDriven.EventBus.Abstractions to 1.4.0
- Upgrade to Dapr 1.12.0
- Set version to 1.4.0

Closes #30 [Feature] Should allow retries in case of processing exception
Closes #36 [Bug] Serialization Error
Closes #35 [Feature] Add Support for Retries
