### PR TITLE
Switched to a more performant locking library

### DIFF
--- a/src/EventDriven.EventBus.Dapr.EventCache.Mongo/DaprEventCache.cs
+++ b/src/EventDriven.EventBus.Dapr.EventCache.Mongo/DaprEventCache.cs
@@ -1,8 +1,8 @@
+using AsyncKeyedLock;
 using Dapr.Client;
 using EventDriven.EventBus.Abstractions;
 using EventDriven.EventBus.EventCache.Mongo;
 using Microsoft.Extensions.Options;
-using NeoSmart.AsyncLock;
 
 namespace EventDriven.EventBus.Dapr.EventCache.Mongo;
 
@@ -10,7 +10,7 @@ namespace EventDriven.EventBus.Dapr.EventCache.Mongo;
 public class DaprEventCache : IEventCache
 {
     private readonly DaprClient _dapr;
-    private readonly AsyncLock _syncRoot = new();
+    private readonly AsyncNonKeyedLocker _syncRoot = new();
     private readonly DaprEventCacheOptions _eventCacheOptions;
     private readonly IEventHandlingRepository<DaprIntegrationEvent> _eventHandlingRepository;
     

--- a/src/EventDriven.EventBus.Dapr/EventDriven.EventBus.Dapr.csproj
+++ b/src/EventDriven.EventBus.Dapr/EventDriven.EventBus.Dapr.csproj
@@ -21,11 +21,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AsyncKeyedLock" Version="6.3.4" />
     <PackageReference Include="Dapr.AspNetCore" Version="1.12.0" />
     <PackageReference Include="EventDriven.EventBus.Abstractions" Version="1.4.0" />
     <PackageReference Include="EventDriven.SchemaRegistry.Mongo" Version="1.2.3" />
     <PackageReference Include="EventDriven.SchemaValidator.Json" Version="2.0.0" />
-    <PackageReference Include="NeoSmart.AsyncLock" Version="3.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/EventDriven.EventBus.Dapr/EventDriven.EventBus.Dapr.csproj
+++ b/src/EventDriven.EventBus.Dapr/EventDriven.EventBus.Dapr.csproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AsyncKeyedLock" Version="6.3.4" />
+    <PackageReference Include="AsyncKeyedLock" Version="6.4.2" />
     <PackageReference Include="Dapr.AspNetCore" Version="1.12.0" />
     <PackageReference Include="EventDriven.EventBus.Abstractions" Version="1.4.0" />
     <PackageReference Include="EventDriven.SchemaRegistry.Mongo" Version="1.2.3" />

--- a/src/EventDriven.EventBus.EventCache.Mongo/EventDriven.EventBus.EventCache.Mongo.csproj
+++ b/src/EventDriven.EventBus.EventCache.Mongo/EventDriven.EventBus.EventCache.Mongo.csproj
@@ -20,6 +20,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="AsyncKeyedLock" Version="6.3.4" />
         <PackageReference Include="EventDriven.DependencyInjection.URF.Mongo" Version="1.2.2" />
         <PackageReference Include="EventDriven.EventBus.Abstractions" Version="1.4.0" />
         <PackageReference Include="MongoDB.Driver" Version="2.22.0" />

--- a/src/EventDriven.EventBus.EventCache.Mongo/EventDriven.EventBus.EventCache.Mongo.csproj
+++ b/src/EventDriven.EventBus.EventCache.Mongo/EventDriven.EventBus.EventCache.Mongo.csproj
@@ -20,7 +20,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AsyncKeyedLock" Version="6.3.4" />
+        <PackageReference Include="AsyncKeyedLock" Version="6.4.2" />
         <PackageReference Include="EventDriven.DependencyInjection.URF.Mongo" Version="1.2.2" />
         <PackageReference Include="EventDriven.EventBus.Abstractions" Version="1.4.0" />
         <PackageReference Include="MongoDB.Driver" Version="2.22.0" />

--- a/src/EventDriven.EventBus.EventCache.Mongo/MongoEventCache.cs
+++ b/src/EventDriven.EventBus.EventCache.Mongo/MongoEventCache.cs
@@ -1,13 +1,13 @@
+using AsyncKeyedLock;
 using EventDriven.EventBus.Abstractions;
 using Microsoft.Extensions.Options;
-using NeoSmart.AsyncLock;
 
 namespace EventDriven.EventBus.EventCache.Mongo;
 
 /// <inheritdoc />
 public class MongoEventCache : IEventCache
 {
-    private readonly AsyncLock _syncRoot = new();
+    private readonly AsyncNonKeyedLocker _syncRoot = new();
     private readonly MongoEventCacheOptions _eventCacheOptions;
     private readonly IEventHandlingRepository<DaprIntegrationEvent> _eventHandlingRepository;
 


### PR DESCRIPTION
Disclaimer: I am the author of the new library.

Public benchmarks running on GitHub show AsyncNonKeyedLocker to be considerably more performant; in tests NeoSmart.AsyncLock took 9.71x the time and allocated 7.42x the memory.

https://github.com/MarkCiliaVincenti/AsyncNonKeyedLockBenchmarks/actions/runs/7526873065/job/20485876144